### PR TITLE
refactor: remove unnecessary cloning and simplify code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /result
 /messages.txt
 /accounts.txt
+/.idea

--- a/src/proto/wrac.rs
+++ b/src/proto/wrac.rs
@@ -35,7 +35,7 @@ pub fn accept_wrac_stream(
 
             if id == 0x00 {
                 if data.is_empty() {
-                    let total_size = on_total_size(ctx.clone(), addr.clone())?;
+                    let total_size = on_total_size(ctx.clone(), addr)?;
                     sent_size = Some(total_size);
 
                     websocket.write(Message::Binary(Bytes::from(
@@ -50,7 +50,7 @@ pub fn accept_wrac_stream(
                     if id == 0x01 {
                         websocket.write(Message::Binary(Bytes::from(on_total_data(
                             ctx.clone(),
-                            addr.clone(),
+                            addr,
                             sent_size,
                         )?)))?;
                         websocket.flush()?;
@@ -58,7 +58,7 @@ pub fn accept_wrac_stream(
                         let client_has = String::from_utf8(data)?.parse()?;
                         websocket.write(Message::Binary(Bytes::from(on_chunked_data(
                             ctx.clone(),
-                            addr.clone(),
+                            addr,
                             sent_size,
                             client_has,
                         )?)))?;
@@ -66,7 +66,7 @@ pub fn accept_wrac_stream(
                     }
                 }
             } else if id == 0x01 {
-                on_send_message(ctx.clone(), addr.clone(), data)?;
+                on_send_message(ctx.clone(), addr, data)?;
             } else if id == 0x02 {
                 let msg = String::from_utf8_lossy(&data).to_string();
 
@@ -83,7 +83,7 @@ pub fn accept_wrac_stream(
                 };
 
                 if let Some(resp_id) =
-                    on_send_auth_message(ctx.clone(), addr.clone(), name, password, text)?
+                    on_send_auth_message(ctx.clone(), addr, name, password, text)?
                 {
                     websocket.write(Message::Binary(Bytes::from(vec![resp_id])))?;
                     websocket.flush()?;
@@ -96,12 +96,12 @@ pub fn accept_wrac_stream(
                 let Some(name) = segments.next() else {
                     return Ok(());
                 };
+
                 let Some(password) = segments.next() else {
                     return Ok(());
                 };
 
-                if let Some(resp_id) = on_register_user(ctx.clone(), addr.clone(), name, password)?
-                {
+                if let Some(resp_id) = on_register_user(ctx.clone(), addr, name, password)? {
                     websocket.write(Message::Binary(Bytes::from(vec![resp_id])))?;
                     websocket.flush()?;
                 }


### PR DESCRIPTION
- Removed redundant `.clone()` calls.
- Replaced manual iterations with `.iter().find()` for searching accounts.
  ```rust
      pub fn get_account_by_addr(&self, addr: &str) -> Option<Account> {
        self.accounts
            .read()
            .unwrap()
            .iter()
            .find(|acc| acc.addr() == addr)
            .cloned()
    }

    pub fn get_account(&self, name: &str) -> Option<Account> {
        self.accounts
            .read()
            .unwrap()
            .iter()
            .find(|acc| acc.name() == name)
            .cloned()
    }
    ```
- Refactored `Account::from_bytes` function to reduce code duplication with helper functions.
  ```rust
  let read_u32 = |cursor: &mut Cursor<Vec<u8>>| -> Result<u32, Box<dyn Error>> {
      let mut buf = [0; 4];
      cursor.read_exact(&mut buf)?;
      Ok(u32::from_le_bytes(buf))
  };
        
  let name_len = read_u32(&mut cursor)? as usize;
  let salt_len = read_u32(&mut cursor)? as usize;
  let addr_len = read_u32(&mut cursor)? as usize;
  let pass_len = read_u32(&mut cursor)? as usize;
        
  let read_string = |cursor: &mut Cursor<Vec<u8>>, len: usize| -> Result<String, Box<dyn Error>> {
      let mut buf = vec![0; len];
      cursor.read_exact(&mut buf)?;
      String::from_utf8(buf).map_err(|e| e.into())
  };
        
  let name = read_string(&mut cursor, name_len)?;
  let salt = read_string(&mut cursor, salt_len)?;
  let addr = read_string(&mut cursor, addr_len)?;
  ```